### PR TITLE
Fix broken feed for episode "Chapters 37-40"

### DIFF
--- a/not-everything-is-a-clue.rss
+++ b/not-everything-is-a-clue.rss
@@ -48,9 +48,9 @@
 				</div>
 				</div>
 			]]></content:encoded>
-			<description><img loading="lazy" class="alignleft size-medium wp-image-2828" src="https://hpmorpodcast.</description>
-			<itunes:subtitle><img loading="lazy" class="alignleft size-medium wp-image-2828" src="https://hpmorpodcast.</itunes:subtitle>
-			<itunes:summary><img loading="lazy" class="alignleft size-medium wp-image-2828" src="https://hpmorpodcast.</itunes:summary>
+			<description>Eneasz Flickers In and Out of Reality.</description>
+			<itunes:subtitle>Eneasz Flickers In and Out of Reality.</itunes:subtitle>
+			<itunes:summary>Eneasz Flickers In and Out of Reality.</itunes:summary>
 			<itunes:author>Eneasz Brodski</itunes:author>
 			<enclosure url="http://media.blubrry.com/hpmor/s/www.hpmorpodcast.com/wp-content/uploads/episodes/Not_a_Clue_013.mp3" length="239575248" type="audio/mpeg" />
 			<itunes:duration>2:46:22</itunes:duration>


### PR DESCRIPTION
Podcast Addict was complaining to me that there was an error in the feed. The description tags for Chapters 37-40 had some unclosed HTML tags, which didn't look like the intended text. I've replaced them with the text description of the episode.